### PR TITLE
Updating tsconfig files, updating package dev dependencies, using imports over requires in backend server

### DIFF
--- a/app/backend/app.js
+++ b/app/backend/app.js
@@ -1,20 +1,60 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_1 = require("./config");
-const path = require('path');
-const http = require('http');
-const express = require('express');
-const app = express();
-const bodyParser = require('body-parser');
-const cookieParser = require("cookie-parser");
-const favicon = require('serve-favicon');
-const session = require('express-session');
+const body_parser_1 = __importDefault(require("body-parser"));
+const cookie_parser_1 = __importDefault(require("cookie-parser"));
+const express_1 = __importDefault(require("express"));
+const express_session_1 = __importDefault(require("express-session"));
+const http_1 = __importDefault(require("http"));
+const morgan_1 = __importDefault(require("morgan"));
+const path_1 = __importDefault(require("path"));
+const serve_favicon_1 = __importDefault(require("serve-favicon"));
 const random_1 = require("./lib/random");
 const session_1 = require("./storage/session");
+const indexRoute = __importStar(require("./route"));
+const resultRoute = __importStar(require("./route/result"));
+const tokenRoute = __importStar(require("./route/token"));
+const app = (0, express_1.default)();
 const avsStorageInstance = new session_1.AvsStorageSession();
-app.use(bodyParser.urlencoded({ extended: false }));
-app.use(cookieParser());
-app.use(session({
+app.use(body_parser_1.default.urlencoded({ extended: false }));
+app.use((0, cookie_parser_1.default)());
+app.use((0, express_session_1.default)({
     secret: random_1.AvsRandom.generateRandomString(),
     resave: false,
     saveUninitialized: true,
@@ -22,23 +62,19 @@ app.use(session({
         secure: false
     }
 }));
-app.use(express.static('app/frontend'));
-app.use(favicon(path.join(__dirname, '../frontend/static', 'favicon.ico')));
-const server = http.Server(app);
-const morgan = require('morgan');
-app.use(morgan('combined'));
+app.use(express_1.default.static('app/frontend'));
+app.use((0, serve_favicon_1.default)(path_1.default.join(__dirname, '../frontend/static', 'favicon.ico')));
+const server = new http_1.default.Server(app);
+app.use((0, morgan_1.default)('combined'));
 app.set('views', config_1.config.htmlFilePath);
 app.set('twig options', {
     allowAsync: true,
     strict_variables: false
 });
 app.locals.cacheBuster = config_1.config.cacheBuster;
-let indexRoute = require('./route');
-let resultRoute = require('./route/result');
-let tokenRoute = require('./route/token');
 tokenRoute.load(app, avsStorageInstance);
 resultRoute.load(app, avsStorageInstance);
 indexRoute.load(app, avsStorageInstance);
 server.listen(config_1.config.httpServerPort, config_1.config.httpServerHost, () => {
-    console.log('http server started on: ' + config_1.config.httpServerHost + ':' + config_1.config.httpServerPort);
+    console.log('http server started on: ' + config_1.config.httpServerProtocol + '://' + config_1.config.httpServerHost + ':' + config_1.config.httpServerPort);
 });

--- a/app/backend/lib/encryption.js
+++ b/app/backend/lib/encryption.js
@@ -1,12 +1,15 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.AvsEncryption = void 0;
+const crypto_1 = __importDefault(require("crypto"));
 const config_1 = require("../config");
-const crypto = require('crypto');
 class AvsEncryption {
     static encryptObject(object) {
-        const iv = crypto.randomBytes(16);
-        let cipher = crypto.createCipheriv(config_1.config.encryption.algorithm, Buffer.from(config_1.config.encryption.key), iv);
+        const iv = crypto_1.default.randomBytes(16);
+        let cipher = crypto_1.default.createCipheriv(config_1.config.encryption.algorithm, Buffer.from(config_1.config.encryption.key), iv);
         let encrypted = cipher.update(JSON.stringify(object));
         encrypted = Buffer.concat([encrypted, cipher.final()]);
         return iv.toString('hex') + '|:' + encrypted.toString('hex');
@@ -15,7 +18,7 @@ class AvsEncryption {
         let encryptedStringParts = encryptedString.split(':');
         let iv = Buffer.from(encryptedStringParts[0], 'hex');
         let encryptedData = Buffer.from(encryptedStringParts[1], 'hex');
-        let decipher = crypto.createDecipheriv(config_1.config.encryption.algorithm, Buffer.from(config_1.config.encryption.key), iv);
+        let decipher = crypto_1.default.createDecipheriv(config_1.config.encryption.algorithm, Buffer.from(config_1.config.encryption.key), iv);
         let decrypted = decipher.update(encryptedData);
         decrypted = Buffer.concat([decrypted, decipher.final()]);
         return JSON.parse(decrypted.toString());

--- a/app/backend/lib/random.js
+++ b/app/backend/lib/random.js
@@ -1,10 +1,13 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.AvsRandom = void 0;
-const Crypto = require('crypto');
+const crypto_1 = __importDefault(require("crypto"));
 class AvsRandom {
     static generateRandomString(length = 16) {
-        return Crypto
+        return crypto_1.default
             .randomBytes(length)
             .toString('base64')
             .slice(0, length);

--- a/app/backend/route/index.js
+++ b/app/backend/route/index.js
@@ -1,13 +1,16 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.load = void 0;
-const URL = require("url");
-const encryption_1 = require("../lib/encryption");
+exports.load = load;
+const node_fs_1 = __importDefault(require("node:fs"));
+const path_1 = __importDefault(require("path"));
+const url_1 = __importDefault(require("url"));
 const config_1 = require("../config");
+const encryption_1 = require("../lib/encryption");
 const response_1 = require("../lib/response");
 const session_1 = require("../storage/session");
-const fs = require('node:fs');
-const path = require('path');
 function load(app, storage) {
     app.use((req, res, next) => {
         next();
@@ -81,7 +84,7 @@ function load(app, storage) {
                 d: requestPayload
             },
         };
-        const urlTokenString = URL.format(urlToken);
+        const urlTokenString = url_1.default.format(urlToken);
         const urlIframe = {
             protocol: config_1.config.httpServerProtocol,
             hostname: config_1.config.httpServerHost,
@@ -91,7 +94,7 @@ function load(app, storage) {
                 d: requestPayload
             },
         };
-        const urlIframeString = URL.format(urlIframe);
+        const urlIframeString = url_1.default.format(urlIframe);
         res.send(response_1.AvsResponse.successResponse({
             payload: requestPayload,
             url: urlTokenString,
@@ -119,7 +122,7 @@ function load(app, storage) {
     });
     app.post('/callback', (req, res) => {
         let responseString = JSON.stringify(req.body) + "\n";
-        fs.appendFile(path.join(__dirname, './../../../log/callback.log'), responseString, (err) => {
+        node_fs_1.default.appendFile(path_1.default.join(__dirname, './../../../log/callback.log'), responseString, (err) => {
             if (err) {
                 res.send(response_1.AvsResponse.errorResponse(30004, 'Callback file log error: ' + err.toString()));
                 return;
@@ -137,4 +140,3 @@ function load(app, storage) {
         res.send('404');
     });
 }
-exports.load = load;

--- a/app/backend/route/result.js
+++ b/app/backend/route/result.js
@@ -1,9 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.load = void 0;
+exports.load = load;
+const config_1 = require("../config");
 const response_1 = require("../lib/response");
 const session_1 = require("../storage/session");
-const config_1 = require("../config");
 const ROUTE_ROOT = '/result';
 const MAX_TEST_DURATION = config_1.config.test.maxDuration;
 const DEVICE_LOCATION_VERIFICATION_INTERNAL = 0;
@@ -129,4 +129,3 @@ function load(app, storage) {
         return delta < MAX_TEST_DURATION;
     };
 }
-exports.load = load;

--- a/app/backend/route/token.js
+++ b/app/backend/route/token.js
@@ -1,11 +1,14 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.load = void 0;
+exports.load = load;
+const ua_parser_js_1 = __importDefault(require("ua-parser-js"));
 const config_1 = require("../config");
 const encryption_1 = require("../lib/encryption");
 const random_1 = require("../lib/random");
 const session_1 = require("../storage/session");
-const uaParser = require('ua-parser-js');
 const ROUTE_ROOT = '/token';
 function load(app, storage) {
     app.get(ROUTE_ROOT, (req, res) => {
@@ -60,7 +63,7 @@ function load(app, storage) {
         req.session.accessTime = +new Date();
         req.session.sessionStartId = avsSession.sessionId;
         req.session.payload = payload;
-        let userAgent = typeof req.headers['user-agent'] != 'undefined' ? uaParser(req.headers['user-agent']) : '';
+        let userAgent = typeof req.headers['user-agent'] != 'undefined' ? (0, ua_parser_js_1.default)(req.headers['user-agent']) : '';
         res.render('token/index.twig', {
             js: {
                 onDocumentReady: 'AvsToken.main',
@@ -83,4 +86,3 @@ function load(app, storage) {
         });
     };
 }
-exports.load = load;

--- a/app/backend/storage/session.js
+++ b/app/backend/storage/session.js
@@ -4,10 +4,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.AvsStorageSession = void 0;
+const axios_1 = __importDefault(require("axios"));
+const ua_parser_js_1 = __importDefault(require("ua-parser-js"));
 const encryption_1 = require("../lib/encryption");
 const payload_1 = require("./payload");
-const axios_1 = __importDefault(require("axios"));
-const uaParser = require('ua-parser-js');
 class AvsStorageSession {
     constructor() {
         this.sessionIdStart = this.getNow();
@@ -45,7 +45,7 @@ class AvsStorageSession {
         this.payloadInstance.store(payload);
         let payloadParsed = encryption_1.AvsEncryption.decryptString(payload);
         let sessionId = this.getUniqueId();
-        let uaParsed = uaParser(payloadParsed.httpParamList.userAgent);
+        let uaParsed = (0, ua_parser_js_1.default)(payloadParsed.httpParamList.userAgent);
         let sessionState = AvsStorageSession.SESSION_STATE_IN_PROGRESS;
         if (this.payloadInstance.isStored(payload)) {
             sessionState = AvsStorageSession.SESSION_STATE_LINK_ALREADY_USED;

--- a/app/frontend/static/js/app/avs.js
+++ b/app/frontend/static/js/app/avs.js
@@ -6048,7 +6048,7 @@ var Avs;
                             },
                             "idRegionZoom": 2
                         }
-                    ]
+                    ],
                 }
             },
             "RO": {
@@ -15835,7 +15835,7 @@ var Avs;
                                 }
                             ]
                         }
-                    }
+                    },
                 }
             }
         };
@@ -15930,7 +15930,7 @@ var Avs;
                 this.debug.info('Trying to start the stream using resolution: ' + JSON.stringify(this.resolutionFallbackList[this.currentFallbackStep]));
                 var videoConstraints = {
                     width: { ideal: this.resolutionFallbackList[this.currentFallbackStep].width },
-                    height: { ideal: this.resolutionFallbackList[this.currentFallbackStep].height }
+                    height: { ideal: this.resolutionFallbackList[this.currentFallbackStep].height },
                 };
                 if (streamVideoInputDevice !== null) {
                     videoConstraints.deviceId = { exact: streamVideoInputDevice };
@@ -15940,7 +15940,7 @@ var Avs;
                     videoConstraints.facingMode = { exact: facingMode };
                 }
                 navigator.mediaDevices.getUserMedia({
-                    video: videoConstraints
+                    video: videoConstraints,
                 }).then(function (stream) {
                     _this.streamInstance = stream;
                     _this.videoElement.srcObject = stream;
@@ -16161,7 +16161,7 @@ var Avs;
                         "WA": 18,
                         "WI": 18,
                         "WV": 18,
-                        "WY": 18
+                        "WY": 18,
                     }
                 };
             };
@@ -16533,7 +16533,7 @@ var Avs;
                     for (var pluginName in this.config.plugin.Library[pluginCategory]) {
                         if (this.config.plugin.Library[pluginCategory].hasOwnProperty(pluginName)) {
                             this.plugin.Library[pluginCategory][pluginName] = new Avs.Plugin.Library[pluginCategory][pluginName](this.config.plugin.Library[pluginCategory][pluginName], this.event, {
-                                apiDataChannel: this.apiDataChannel
+                                apiDataChannel: this.apiDataChannel,
                             });
                         }
                     }
@@ -17101,7 +17101,7 @@ var Avs;
                             devices[device.kind].push({
                                 id: device.deviceId,
                                 label: device.label,
-                                "default": device.deviceId == 'default'
+                                default: device.deviceId == 'default'
                             });
                         }
                         return callback(devices);
@@ -17622,7 +17622,7 @@ var Avs;
                     width: positioning.width,
                     height: positioning.height,
                     top: positioning.top,
-                    left: positioning.left
+                    left: positioning.left,
                 });
             };
             return ElementPositionCalculator;
@@ -19820,7 +19820,7 @@ var Avs;
                             top: faceDetection.alignedRect._box.top,
                             left: faceDetection.alignedRect._box.left,
                             imageWidth: faceDetection.alignedRect._imageDims.width,
-                            imageHeight: faceDetection.alignedRect._imageDims.height
+                            imageHeight: faceDetection.alignedRect._imageDims.height,
                         };
                     };
                     FaceApi.DETECTOR_TYPE_SSD_MOBILE_NET_V1 = 'ssd_mobilenetv1';
@@ -19889,7 +19889,7 @@ var Avs;
                                 '09': 'sept',
                                 '10': 'oct',
                                 '11': 'nov',
-                                '12': 'déc'
+                                '12': 'déc',
                             },
                             _a[Tesseract.MONTH_NAME_LANGUAGE_EN] = {
                                 '01': 'jan',
@@ -19903,7 +19903,7 @@ var Avs;
                                 '09': 'sept',
                                 '10': 'oct',
                                 '11': 'nov',
-                                '12': 'dec'
+                                '12': 'dec',
                             },
                             _a[Tesseract.MONTH_NAME_LANGUAGE_BE] = {
                                 '01': 'jan',
@@ -19917,7 +19917,7 @@ var Avs;
                                 '09': 'sept',
                                 '10': 'oct',
                                 '11': 'nov',
-                                '12': 'dec'
+                                '12': 'dec',
                             },
                             _a[Tesseract.MONTH_NAME_LANGUAGE_NL] = {
                                 '01': 'jan',
@@ -19931,7 +19931,7 @@ var Avs;
                                 '09': 'sept',
                                 '10': 'oct',
                                 '11': 'nov',
-                                '12': 'dec'
+                                '12': 'dec',
                             },
                             _a[Tesseract.MONTH_NAME_LANGUAGE_EL] = {
                                 '01': 'ian',
@@ -19945,7 +19945,7 @@ var Avs;
                                 '09': 'sept',
                                 '10': 'okt',
                                 '11': 'noem',
-                                '12': 'dek'
+                                '12': 'dek',
                             },
                             _a);
                         // TODO: load the library on demand
@@ -19960,7 +19960,7 @@ var Avs;
                             corePath: _this.config.corePath,
                             cacheMethod: 'refresh',
                             logger: function (result) {
-                            }
+                            },
                         });
                         _this.videoElement = $(_this.config.videoElementSelector).get(0);
                         _this.workerLoaded = false;
@@ -20143,7 +20143,7 @@ var Avs;
                                 var scanIdPersonYears = Math.floor(((dateNow - dateFound) / 1000 / 3600 / 24 / 365.2425));
                                 cb({
                                     birthDate: dateFoundString,
-                                    age: scanIdPersonYears
+                                    age: scanIdPersonYears,
                                 });
                             }
                             else {
@@ -20222,12 +20222,12 @@ var Avs;
                         var _this = _super.call(this, config, event, api) || this;
                         _this.api = api;
                         _this.adapters = {
-                            webrtc: new Avs.Video.Webrtc(_this.config.webrtc, _this.event)
+                            webrtc: new Avs.Video.Webrtc(_this.config.webrtc, _this.event),
                         };
                         _this.config.webrtc.options.localVideo = _this.adapters.webrtc.getRootElement();
                         _this.config.webrtc.options.eventNamesPrefix = _this.config.webrtc.options.eventNamesPrefix || CameraSource.EVENT_NAME_PREFIX;
                         _this.datachannels = {
-                            webrtc: new Avs.DataChannel.Webrtc(_this.config.webrtc, _this.event, _this.api)
+                            webrtc: new Avs.DataChannel.Webrtc(_this.config.webrtc, _this.event, _this.api),
                         };
                         _this.currentAdapter = 'webrtc';
                         return _this;
@@ -24203,7 +24203,7 @@ var Avs;
                         visible: this.element.is(':visible'),
                         enabled: !this.element.attr('disabled'),
                         value: this.element.val(),
-                        name: this.element.find('option:selected').text()
+                        name: this.element.find('option:selected').text(),
                     };
                     this.states = entity.states.FaceApiTypeSelect;
                 };
@@ -24258,7 +24258,7 @@ var Avs;
                         visible: this.element.is(':visible'),
                         enabled: !this.element.attr('disabled'),
                         value: this.element.val(),
-                        name: this.element.find('option:selected').text()
+                        name: this.element.find('option:selected').text(),
                     };
                     this.states = entity.states.ScanIdAgeVerificationCountrySelect;
                 };
@@ -24313,7 +24313,7 @@ var Avs;
                         visible: this.element.is(':visible'),
                         enabled: !this.element.attr('disabled'),
                         value: this.element.val(),
-                        name: this.element.find('option:selected').text()
+                        name: this.element.find('option:selected').text(),
                     };
                     this.states = entity.states.ScanIdAgeVerificationDeviceSelect;
                 };
@@ -24368,7 +24368,7 @@ var Avs;
                         visible: this.element.is(':visible'),
                         enabled: !this.element.attr('disabled'),
                         value: this.element.val(),
-                        name: this.element.find('option:selected').text()
+                        name: this.element.find('option:selected').text(),
                     };
                     this.states = entity.states.ScanIdAgeVerificationStateSelect;
                 };
@@ -24423,7 +24423,7 @@ var Avs;
                         visible: this.element.is(':visible'),
                         enabled: !this.element.attr('disabled'),
                         value: this.element.val(),
-                        name: this.element.find('option:selected').text()
+                        name: this.element.find('option:selected').text(),
                     };
                     this.states = entity.states.ScanIdAgeVerificationTypeSelect;
                 };
@@ -24478,7 +24478,7 @@ var Avs;
                         visible: this.element.is(':visible'),
                         enabled: !this.element.attr('disabled'),
                         value: this.element.val(),
-                        name: this.element.find('option:selected').text()
+                        name: this.element.find('option:selected').text(),
                     };
                     this.states = entity.states.SelfieAgeDetectionDeviceSelect;
                 };
@@ -24533,7 +24533,7 @@ var Avs;
                         visible: this.element.is(':visible'),
                         enabled: !this.element.attr('disabled'),
                         value: this.element.val(),
-                        name: this.element.find('option:selected').text()
+                        name: this.element.find('option:selected').text(),
                     };
                     this.states = entity.states.TesseractTypeSelect;
                 };
@@ -24588,7 +24588,7 @@ var Avs;
                         visible: this.element.is(':visible'),
                         enabled: !this.element.attr('disabled'),
                         value: this.element.val(),
-                        name: this.element.find('option:selected').text()
+                        name: this.element.find('option:selected').text(),
                     };
                     this.states = entity.states.VerificationTypeSelect;
                 };

--- a/app/frontend/static/js/app/avsFactory.js
+++ b/app/frontend/static/js/app/avsFactory.js
@@ -34,7 +34,7 @@ var AvsFactory;
                     ResultPageFailReasonArea: new Avs.Ui.Library.ResultPageFailReasonArea(ResultPageFail.instance.event),
                     ErrorMessageQrTextArea: new Avs.Ui.Library.ErrorMessageQrTextArea(ResultPageFail.instance.event),
                     ResultPageFailQrArea: new Avs.Ui.Library.ResultPageFailQrArea(ResultPageFail.instance.event),
-                    FailPageErrorQrCode: new Avs.Ui.Library.FailPageErrorQrCode(ResultPageFail.instance.event)
+                    FailPageErrorQrCode: new Avs.Ui.Library.FailPageErrorQrCode(ResultPageFail.instance.event),
                 };
             };
             return Ui;
@@ -84,7 +84,7 @@ var AvsFactory;
                     sessionId: ResultPageFail.instance.entity.VerificationStepGlobal.sessionId,
                     idCountry: ResultPageFail.instance.entity.ScanIdAgeVerification.idCountry,
                     idState: ResultPageFail.instance.entity.ScanIdAgeVerification.idState,
-                    idType: ResultPageFail.instance.entity.ScanIdAgeVerification.idTypeString
+                    idType: ResultPageFail.instance.entity.ScanIdAgeVerification.idTypeString,
                 }).then(function () {
                 }, function (error) {
                     ResultPageFail.instance.ui.ResultPageFailReasonArea.setContent(error.code + ': Could not save your result');
@@ -151,7 +151,7 @@ var AvsFactory;
                     pollingEndpoint: ResultPageFail.Config.POLLING_BASE_ENDPOINT
                 },
                 event: {
-                    debugLevel: ResultPageFail.Config.DEFAULT_DEBUG_LEVEL
+                    debugLevel: ResultPageFail.Config.DEFAULT_DEBUG_LEVEL,
                 }
             });
             ResultPageFail.Ui.init();
@@ -198,7 +198,7 @@ var AvsFactory;
                 ResultPageSuccess.instance.ui = {
                     ResultPageSuccessScanIdArea: new Avs.Ui.Library.ResultPageSuccessScanIdArea(ResultPageSuccess.instance.event),
                     ResultPageSuccessSelfieArea: new Avs.Ui.Library.ResultPageSuccessSelfieArea(ResultPageSuccess.instance.event),
-                    ResultSuccessButton: new Avs.Ui.Library.ResultSuccessButton(ResultPageSuccess.instance.event)
+                    ResultSuccessButton: new Avs.Ui.Library.ResultSuccessButton(ResultPageSuccess.instance.event),
                 };
             };
             return Ui;
@@ -269,7 +269,7 @@ var AvsFactory;
                     sessionId: ResultPageSuccess.instance.entity.VerificationStepGlobal.sessionId,
                     idCountry: ResultPageSuccess.instance.entity.ScanIdAgeVerification.idCountry,
                     idState: ResultPageSuccess.instance.entity.ScanIdAgeVerification.idState,
-                    idType: ResultPageSuccess.instance.entity.ScanIdAgeVerification.idTypeString
+                    idType: ResultPageSuccess.instance.entity.ScanIdAgeVerification.idTypeString,
                 }).then(function (successData) {
                     ResultPageSuccess.instance.entity.VerificationStepGlobal.isVerified = true;
                     ResultPageSuccess.instance.entity.VerificationStepGlobal.successPayload = successData.successPayload;
@@ -315,7 +315,7 @@ var AvsFactory;
                     apiEndpoint: ResultPageSuccess.Config.API_BASE_ENDPOINT
                 },
                 event: {
-                    debugLevel: ResultPageSuccess.Config.DEFAULT_DEBUG_LEVEL
+                    debugLevel: ResultPageSuccess.Config.DEFAULT_DEBUG_LEVEL,
                 }
             });
             ResultPageSuccess.Ui.init();
@@ -371,7 +371,7 @@ var AvsFactory;
                     ScanIdAgeVerificationDocumentHelperArea: new Avs.Ui.Library.ScanIdAgeVerificationDocumentHelperArea(ScanIdAgeVerificationIntro.instance.event),
                     ScanIdAgeDetectionCancelButton: new Avs.Ui.Library.ScanIdAgeDetectionCancelButton(ScanIdAgeVerificationIntro.instance.event),
                     ScanIdAgeVerificationUploadImageIntroButton: new Avs.Ui.Library.ScanIdAgeVerificationUploadImageIntroButton(ScanIdAgeVerificationIntro.instance.event),
-                    ScanIdAgeVerificationUploadFileIntroInput: new Avs.Ui.Library.ScanIdAgeVerificationUploadFileIntroInput(ScanIdAgeVerificationIntro.instance.event)
+                    ScanIdAgeVerificationUploadFileIntroInput: new Avs.Ui.Library.ScanIdAgeVerificationUploadFileIntroInput(ScanIdAgeVerificationIntro.instance.event),
                 };
                 ScanIdAgeVerificationIntro.instance.ui.ScanIdAgeVerificationTypeArea.hide();
                 ScanIdAgeVerificationIntro.instance.ui.ScanIdAgeVerificationDocumentHelperArea.hide();
@@ -468,7 +468,7 @@ var AvsFactory;
                                 for (var i = 0, j = devices.videoinput.length; i < j; i++) {
                                     var device = devices.videoinput[i];
                                     videoInputDeviceIdList[device.id] = true;
-                                    ScanIdAgeVerificationIntro.instance.ui.ScanIdAgeVerificationDeviceSelect.addOption(device.label, device.id, device["default"]);
+                                    ScanIdAgeVerificationIntro.instance.ui.ScanIdAgeVerificationDeviceSelect.addOption(device.label, device.id, device.default);
                                     foundDevicesNumber++;
                                 }
                                 if (foundDevicesNumber > 1) {
@@ -588,7 +588,7 @@ var AvsFactory;
             ScanIdAgeVerificationIntro.instance = new Avs.ScanIdAgeVerificationIntro({
                 debugLevel: ScanIdAgeVerificationIntro.Config.DEFAULT_DEBUG_LEVEL,
                 event: {
-                    debugLevel: ScanIdAgeVerificationIntro.Config.DEFAULT_DEBUG_LEVEL
+                    debugLevel: ScanIdAgeVerificationIntro.Config.DEFAULT_DEBUG_LEVEL,
                 }
             });
             ScanIdAgeVerificationIntro.instance.entity.VerificationStepGlobal.stepId = Avs.Entity.VerificationStepGlobal.STEP_SCAN_ID_AGE_VERIFICATION_INTRO;
@@ -700,7 +700,7 @@ var AvsFactory;
                     ScanIdAgeVerificationConfirmationYesButton: new Avs.Ui.Library.ScanIdAgeVerificationConfirmationYesButton(ScanIdAgeVerificationPage.instance.event),
                     ScanIdAgeVerificationConfirmationNoButton: new Avs.Ui.Library.ScanIdAgeVerificationConfirmationNoButton(ScanIdAgeVerificationPage.instance.event),
                     DocumentProcessingCanvasLoadingOverlayArea: new Avs.Ui.Library.DocumentProcessingCanvasLoadingOverlayArea(ScanIdAgeVerificationPage.instance.event),
-                    ScanIdAgeVerificationFaceSimilarityArea: new Avs.Ui.Library.ScanIdAgeVerificationFaceSimilarityArea(ScanIdAgeVerificationPage.instance.event)
+                    ScanIdAgeVerificationFaceSimilarityArea: new Avs.Ui.Library.ScanIdAgeVerificationFaceSimilarityArea(ScanIdAgeVerificationPage.instance.event),
                 };
                 ScanIdAgeVerificationPage.instance.ui.ScanIdAgeVerificationLoadingLabelPercentCounter.setStepNumber(7);
                 ScanIdAgeVerificationPage.instance.ui.ScanIdAgeVerificationBirthDateButton.showLoading();
@@ -1132,7 +1132,7 @@ var AvsFactory;
             ScanIdAgeVerificationPage.instance = new Avs.SelfieAgeDetectionPage({
                 debugLevel: ScanIdAgeVerificationPage.Config.DEFAULT_DEBUG_LEVEL,
                 event: {
-                    debugLevel: ScanIdAgeVerificationPage.Config.DEFAULT_DEBUG_LEVEL
+                    debugLevel: ScanIdAgeVerificationPage.Config.DEFAULT_DEBUG_LEVEL,
                 },
                 plugin: {
                     Library: {
@@ -1142,7 +1142,7 @@ var AvsFactory;
                                 canvasOverlayElementSelector: ScanIdAgeVerificationPage.Config.CAMERA_SOURCE_CANVAS_OVERLAY_ELEMENT,
                                 videoElementSelector: ScanIdAgeVerificationPage.Config.CAMERA_SOURCE_ROOT_ELEMENT,
                                 detectorType: faceApiDetectorType,
-                                debugLevel: ScanIdAgeVerificationPage.Config.DEFAULT_DEBUG_LEVEL
+                                debugLevel: ScanIdAgeVerificationPage.Config.DEFAULT_DEBUG_LEVEL,
                             },
                             Tesseract: {
                                 idConfig: scanIdAgeVerificationEntity.getIdTypeConfig(),
@@ -1150,7 +1150,7 @@ var AvsFactory;
                                 languagePath: ScanIdAgeVerificationPage.Config.TESSERACT_LANGUAGE_PATH,
                                 corePath: ScanIdAgeVerificationPage.Config.TESSERACT_CORE_PATH,
                                 videoElementSelector: ScanIdAgeVerificationPage.Config.CAMERA_SOURCE_ROOT_ELEMENT,
-                                debugLevel: ScanIdAgeVerificationPage.Config.DEFAULT_DEBUG_LEVEL
+                                debugLevel: ScanIdAgeVerificationPage.Config.DEFAULT_DEBUG_LEVEL,
                             }
                         },
                         Video: {
@@ -1217,7 +1217,7 @@ var AvsFactory;
                     SelfieAgeDetectionDeviceAccessArea: new Avs.Ui.Library.SelfieAgeDetectionDeviceAccessArea(SelfieAgeDetectionIntro.instance.event),
                     SelfieAgeDetectionSubmitArea: new Avs.Ui.Library.SelfieAgeDetectionSubmitArea(SelfieAgeDetectionIntro.instance.event),
                     SelfieAgeDetectionDeviceSelectionArea: new Avs.Ui.Library.SelfieAgeDetectionDeviceSelectionArea(SelfieAgeDetectionIntro.instance.event),
-                    SelfieAgeDetectionCancelButton: new Avs.Ui.Library.SelfieAgeDetectionCancelButton(SelfieAgeDetectionIntro.instance.event)
+                    SelfieAgeDetectionCancelButton: new Avs.Ui.Library.SelfieAgeDetectionCancelButton(SelfieAgeDetectionIntro.instance.event),
                 };
                 if (!SelfieAgeDetectionIntro.instance.entity.SelfieAgeDetection.resourcesPreloaded) {
                     SelfieAgeDetectionIntro.instance.ui.SelfieAgeDetectionStartButton.disable();
@@ -1278,7 +1278,7 @@ var AvsFactory;
                             for (var i = 0, j = devices.videoinput.length; i < j; i++) {
                                 var device = devices.videoinput[i];
                                 videoInputDeviceIdList[device.id] = true;
-                                SelfieAgeDetectionIntro.instance.ui.SelfieAgeDetectionDeviceSelect.addOption(device.label, device.id, device["default"]);
+                                SelfieAgeDetectionIntro.instance.ui.SelfieAgeDetectionDeviceSelect.addOption(device.label, device.id, device.default);
                                 foundDevicesNumber++;
                             }
                             if (foundDevicesNumber > 1) {
@@ -1333,7 +1333,7 @@ var AvsFactory;
             SelfieAgeDetectionIntro.instance = new Avs.SelfieAgeDetectionIntro({
                 debugLevel: SelfieAgeDetectionIntro.Config.DEFAULT_DEBUG_LEVEL,
                 event: {
-                    debugLevel: SelfieAgeDetectionIntro.Config.DEFAULT_DEBUG_LEVEL
+                    debugLevel: SelfieAgeDetectionIntro.Config.DEFAULT_DEBUG_LEVEL,
                 }
             });
             SelfieAgeDetectionIntro.instance.entity.VerificationStepGlobal.stepId = Avs.Entity.VerificationStepGlobal.STEP_SELFIE_AGE_DETECTION_INTRO;
@@ -1407,7 +1407,7 @@ var AvsFactory;
                     FaceGuideAgeArea: new Avs.Ui.Library.FaceGuideAgeArea(SelfieAgeDetectionPage.instance.event),
                     FaceGuideSmileStartHintLabel: new Avs.Ui.Library.FaceGuideSmileStartHintLabel(SelfieAgeDetectionPage.instance.event),
                     FaceGuideSmileStopHintLabel: new Avs.Ui.Library.FaceGuideSmileStopHintLabel(SelfieAgeDetectionPage.instance.event),
-                    FaceGuideLoadingProgressBar: new Avs.Ui.Library.FaceGuideLoadingProgressBar(SelfieAgeDetectionPage.instance.event)
+                    FaceGuideLoadingProgressBar: new Avs.Ui.Library.FaceGuideLoadingProgressBar(SelfieAgeDetectionPage.instance.event),
                 };
                 SelfieAgeDetectionPage.instance.ui.SelfieAgeDetectionLoadingLabelPercentCounter.setStepNumber(5);
                 SelfieAgeDetectionPage.instance.ui.FaceGuideLoadingProgressBar.hide();
@@ -1766,7 +1766,7 @@ var AvsFactory;
             SelfieAgeDetectionPage.instance = new Avs.SelfieAgeDetectionPage({
                 debugLevel: SelfieAgeDetectionPage.Config.DEFAULT_DEBUG_LEVEL,
                 event: {
-                    debugLevel: SelfieAgeDetectionPage.Config.DEFAULT_DEBUG_LEVEL
+                    debugLevel: SelfieAgeDetectionPage.Config.DEFAULT_DEBUG_LEVEL,
                 },
                 plugin: {
                     Library: {
@@ -1776,7 +1776,7 @@ var AvsFactory;
                                 canvasOverlayElementSelector: SelfieAgeDetectionPage.Config.CAMERA_SOURCE_CANVAS_OVERLAY_ELEMENT,
                                 videoElementSelector: SelfieAgeDetectionPage.Config.CAMERA_SOURCE_ROOT_ELEMENT,
                                 detectorType: faceApiDetectorType,
-                                debugLevel: SelfieAgeDetectionPage.Config.DEFAULT_DEBUG_LEVEL
+                                debugLevel: SelfieAgeDetectionPage.Config.DEFAULT_DEBUG_LEVEL,
                             }
                         },
                         Video: {
@@ -1912,7 +1912,7 @@ var AvsFactory;
                     WebCamAccessHelpBackButton: new Avs.Ui.Library.WebCamAccessHelpBackButton(StartPage.instance.event),
                     TermsAndConditionsArea: new Avs.Ui.Library.TermsAndConditionsArea(StartPage.instance.event),
                     WebCamAccessHelpArea: new Avs.Ui.Library.WebCamAccessHelpArea(StartPage.instance.event),
-                    StartPageTermsArea: new Avs.Ui.Library.StartPageTermsArea(StartPage.instance.event)
+                    StartPageTermsArea: new Avs.Ui.Library.StartPageTermsArea(StartPage.instance.event),
                 };
                 var ipCountry = Application.ipCountry.toUpperCase();
                 if (Application.forceIpCountry) {
@@ -2244,7 +2244,7 @@ function appGetInternalState() {
     return {
         verificationStepGlobal: verificationStepGlobal,
         selfieAgeDetection: selfieAgeDetection,
-        scanIdAgeVerification: scanIdAgeVerification
+        scanIdAgeVerification: scanIdAgeVerification,
     };
 }
 
@@ -2260,8 +2260,8 @@ var AvsFactory;
                     pollingEndpoint: StartPage.Config.POLLING_BASE_ENDPOINT
                 },
                 event: {
-                    debugLevel: StartPage.Config.DEFAULT_DEBUG_LEVEL
-                }
+                    debugLevel: StartPage.Config.DEFAULT_DEBUG_LEVEL,
+                },
             });
             StartPage.Ui.init();
             StartPage.Event.init();

--- a/app/frontend/static/js/app/common.js
+++ b/app/frontend/static/js/app/common.js
@@ -676,7 +676,7 @@ var AvsHome;
                     colorConfigButtonBackgroundInput: colorConfigButtonBackgroundInput.val().toString(),
                     colorConfigButtonForegroundInput: colorConfigButtonForegroundInput.val().toString(),
                     colorConfigButtonForegroundCTAInput: colorConfigButtonForegroundCTAInput.val().toString(),
-                    callbackUrl: accessInformationCallbackUrlInput.val()
+                    callbackUrl: accessInformationCallbackUrlInput.val(),
                 };
                 Ajax.getVerificationPayloadAndUrl(postData).then(function (data) {
                     exampleImplementationStartRedirectButton.removeAttr('disabled');
@@ -698,7 +698,7 @@ var AvsHome;
                     colorConfigButtonBackgroundInput: colorConfigButtonBackgroundInput.val().toString(),
                     colorConfigButtonForegroundInput: colorConfigButtonForegroundInput.val().toString(),
                     colorConfigButtonForegroundCTAInput: colorConfigButtonForegroundCTAInput.val().toString(),
-                    callbackUrl: accessInformationCallbackUrlInput.val()
+                    callbackUrl: accessInformationCallbackUrlInput.val(),
                 };
                 Ajax.getVerificationPayloadAndUrl(postData).then(function (data) {
                     iframeAvsHandler(data.iframeUrl);
@@ -833,7 +833,7 @@ var AvsToken;
             partnerId: Application.p,
             payload: Application.d,
             sessionId: Application.sessionId,
-            partnerColorConfig: Application.partnerColorConfig
+            partnerColorConfig: Application.partnerColorConfig,
         });
         AvsFactory.StartPage.init();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
 		"": {
 			"name": "gocamopensource",
 			"version": "1.0.0",
-			"license": "Apache-2.0",
+			"license": "AGPL-3.0",
 			"dependencies": {
 				"axios": "^1.6.8",
 				"body-parser": "^1.20.2",
@@ -21,10 +21,14 @@
 				"ua-parser-js": "^1.0.37"
 			},
 			"devDependencies": {
+				"@types/cookie-parser": "^1.4.9",
 				"@types/express": "^4.17.21",
 				"@types/express-session": "^1.18.0",
 				"@types/jquery": "^3.5.29",
-				"@types/node": "^20.12.7",
+				"@types/morgan": "^1.9.10",
+				"@types/node": "^20.19.7",
+				"@types/serve-favicon": "^2.5.7",
+				"@types/ua-parser-js": "^0.7.39",
 				"compass-importer": "^0.4.1",
 				"gulp": "^5.0.0",
 				"gulp-clean": "^0.4.0",
@@ -32,16 +36,14 @@
 				"gulp-sass": "^5.1.0",
 				"gulp-typescript": "^6.0.0-alpha.1",
 				"sass": "^1.76.0",
-				"typescript": "^5.4.5"
+				"typescript": "^5.8.3"
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
-			"integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
-			"dependencies": {
-				"regenerator-runtime": "^0.14.0"
-			},
+			"version": "7.27.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+			"integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -84,6 +86,16 @@
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/cookie-parser": {
+			"version": "1.4.9",
+			"resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+			"integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/express": "*"
 			}
 		},
 		"node_modules/@types/express": {
@@ -140,13 +152,24 @@
 			"integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
 			"dev": true
 		},
-		"node_modules/@types/node": {
-			"version": "20.12.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-			"integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+		"node_modules/@types/morgan": {
+			"version": "1.9.10",
+			"resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
+			"integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/node": {
+			"version": "20.19.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.7.tgz",
+			"integrity": "sha512-1GM9z6BJOv86qkPvzh2i6VW5+VVrXxCLknfmTkWEqz+6DqosiY28XUWCTmBcJ0ACzKqx/iwdIREfo1fwExIlkA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/qs": {
@@ -171,6 +194,16 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/serve-favicon": {
+			"version": "2.5.7",
+			"resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.7.tgz",
+			"integrity": "sha512-z9TNUQXdQ+W/OJMP1e3KOYUZ99qJS4+ZfFOIrPGImcayqKoyifbJSEFkVq1MCKBbqjMZpjPj3B5ilrQAR2+TOw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/express": "*"
+			}
+		},
 		"node_modules/@types/serve-static": {
 			"version": "1.15.7",
 			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
@@ -187,6 +220,13 @@
 			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.8.tgz",
 			"integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
 			"dev": true
+		},
+		"node_modules/@types/ua-parser-js": {
+			"version": "0.7.39",
+			"resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.39.tgz",
+			"integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -394,9 +434,10 @@
 			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
 		},
 		"node_modules/axios": {
-			"version": "1.6.8",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-			"integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+			"integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
 				"form-data": "^4.0.0",
@@ -489,9 +530,10 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-			"integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+			"integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+			"license": "MIT",
 			"dependencies": {
 				"bytes": "3.1.2",
 				"content-type": "~1.0.5",
@@ -501,7 +543,7 @@
 				"http-errors": "2.0.0",
 				"iconv-lite": "0.4.24",
 				"on-finished": "2.4.1",
-				"qs": "6.11.0",
+				"qs": "6.13.0",
 				"raw-body": "2.5.2",
 				"type-is": "~1.6.18",
 				"unpipe": "1.0.0"
@@ -523,21 +565,23 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
 		"node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"fill-range": "^7.0.1"
+				"fill-range": "^7.1.1"
 			},
 			"engines": {
 				"node": ">=8"
@@ -591,12 +635,42 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
 			"integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+			"dev": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2",
 				"get-intrinsic": "^1.2.4",
 				"set-function-length": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -815,31 +889,25 @@
 			"dev": true
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
 		},
 		"node_modules/cookie-parser": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
-			"integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+			"version": "1.4.7",
+			"resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+			"integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+			"license": "MIT",
 			"dependencies": {
-				"cookie": "0.4.1",
+				"cookie": "0.7.2",
 				"cookie-signature": "1.0.6"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/cookie-parser/node_modules/cookie": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-			"integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/cookie-signature": {
@@ -877,6 +945,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -938,6 +1007,20 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/duplexify": {
@@ -1007,9 +1090,10 @@
 			"dev": true
 		},
 		"node_modules/encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -1024,12 +1108,10 @@
 			}
 		},
 		"node_modules/es-define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-			"integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-			"dependencies": {
-				"get-intrinsic": "^1.2.4"
-			},
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -1038,6 +1120,18 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -1054,7 +1148,8 @@
 		"node_modules/escape-html": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
 		},
 		"node_modules/etag": {
 			"version": "1.8.1",
@@ -1077,36 +1172,37 @@
 			}
 		},
 		"node_modules/express": {
-			"version": "4.19.2",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-			"integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+			"version": "4.21.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+			"integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "1.20.2",
+				"body-parser": "1.20.3",
 				"content-disposition": "0.5.4",
 				"content-type": "~1.0.4",
-				"cookie": "0.6.0",
+				"cookie": "0.7.1",
 				"cookie-signature": "1.0.6",
 				"debug": "2.6.9",
 				"depd": "2.0.0",
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"etag": "~1.8.1",
-				"finalhandler": "1.2.0",
+				"finalhandler": "1.3.1",
 				"fresh": "0.5.2",
 				"http-errors": "2.0.0",
-				"merge-descriptors": "1.0.1",
+				"merge-descriptors": "1.0.3",
 				"methods": "~1.1.2",
 				"on-finished": "2.4.1",
 				"parseurl": "~1.3.3",
-				"path-to-regexp": "0.1.7",
+				"path-to-regexp": "0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "6.11.0",
+				"qs": "6.13.0",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
-				"send": "0.18.0",
-				"serve-static": "1.15.0",
+				"send": "0.19.0",
+				"serve-static": "1.16.2",
 				"setprototypeof": "1.2.0",
 				"statuses": "2.0.1",
 				"type-is": "~1.6.18",
@@ -1115,14 +1211,19 @@
 			},
 			"engines": {
 				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/express-session": {
-			"version": "1.18.0",
-			"resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.0.tgz",
-			"integrity": "sha512-m93QLWr0ju+rOwApSsyso838LQwgfs44QtOP/WBiwtAgPIo/SAh1a5c6nn2BR6mFNZehTpqKDESzP+fRHVbxwQ==",
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+			"integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+			"license": "MIT",
 			"dependencies": {
-				"cookie": "0.6.0",
+				"cookie": "0.7.2",
 				"cookie-signature": "1.0.7",
 				"debug": "2.6.9",
 				"depd": "~2.0.0",
@@ -1139,6 +1240,15 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
 			"integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="
+		},
+		"node_modules/express/node_modules/cookie": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+			"integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -1208,10 +1318,11 @@
 			}
 		},
 		"node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
 			},
@@ -1220,12 +1331,13 @@
 			}
 		},
 		"node_modules/finalhandler": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-			"integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+			"integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+			"license": "MIT",
 			"dependencies": {
 				"debug": "2.6.9",
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"on-finished": "2.4.1",
 				"parseurl": "~1.3.3",
@@ -1441,21 +1553,40 @@
 			}
 		},
 		"node_modules/get-intrinsic": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-			"integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
 			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
 				"function-bind": "^1.1.2",
-				"has-proto": "^1.0.1",
-				"has-symbols": "^1.0.3",
-				"hasown": "^2.0.0"
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/glob": {
@@ -1577,11 +1708,12 @@
 			}
 		},
 		"node_modules/gopd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-			"integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-			"dependencies": {
-				"get-intrinsic": "^1.1.3"
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -2176,6 +2308,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
 			"dependencies": {
 				"es-define-property": "^1.0.0"
 			},
@@ -2183,21 +2316,11 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/has-proto": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-			"integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/has-symbols": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -2430,6 +2553,7 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
 			}
@@ -2628,6 +2752,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -2637,9 +2770,13 @@
 			}
 		},
 		"node_modules/merge-descriptors": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-			"integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+			"integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/methods": {
 			"version": "1.1.2",
@@ -2650,12 +2787,13 @@
 			}
 		},
 		"node_modules/micromatch": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"braces": "^3.0.2",
+				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
 			},
 			"engines": {
@@ -2666,6 +2804,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
 			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"license": "MIT",
 			"bin": {
 				"mime": "cli.js"
 			},
@@ -2774,9 +2913,13 @@
 			}
 		},
 		"node_modules/object-inspect": {
-			"version": "1.13.1",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-			"integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -2985,9 +3128,10 @@
 			}
 		},
 		"node_modules/path-to-regexp": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-			"integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
@@ -3078,11 +3222,12 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-			"integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.0.4"
+				"side-channel": "^1.0.6"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -3109,6 +3254,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
 			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -3175,11 +3321,6 @@
 			"engines": {
 				"node": ">= 10.13.0"
 			}
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.14.1",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
 		},
 		"node_modules/remove-bom-buffer": {
 			"version": "3.0.0",
@@ -3408,9 +3549,10 @@
 			}
 		},
 		"node_modules/send": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-			"integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+			"integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+			"license": "MIT",
 			"dependencies": {
 				"debug": "2.6.9",
 				"depd": "2.0.0",
@@ -3430,10 +3572,20 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/send/node_modules/encodeurl": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+			"integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/send/node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
 		},
 		"node_modules/serve-favicon": {
 			"version": "2.5.0",
@@ -3461,14 +3613,15 @@
 			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 		},
 		"node_modules/serve-static": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-			"integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+			"version": "1.16.2",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+			"integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+			"license": "MIT",
 			"dependencies": {
-				"encodeurl": "~1.0.2",
+				"encodeurl": "~2.0.0",
 				"escape-html": "~1.0.3",
 				"parseurl": "~1.3.3",
-				"send": "0.18.0"
+				"send": "0.19.0"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
@@ -3478,6 +3631,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
 			"dependencies": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -3496,14 +3650,69 @@
 			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
 		},
 		"node_modules/side-channel": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-			"integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"license": "MIT",
 			"dependencies": {
-				"call-bind": "^1.0.7",
 				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.4",
-				"object-inspect": "^1.13.1"
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -3745,6 +3954,7 @@
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
 			},
@@ -3813,10 +4023,11 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -3892,10 +4103,11 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-			"dev": true
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/unique-stream": {
 			"version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,14 @@
 	"author": "GoDotCam",
 	"license": "AGPL-3.0",
 	"devDependencies": {
+		"@types/cookie-parser": "^1.4.9",
 		"@types/express": "^4.17.21",
 		"@types/express-session": "^1.18.0",
 		"@types/jquery": "^3.5.29",
-		"@types/node": "^20.12.7",
+		"@types/morgan": "^1.9.10",
+		"@types/node": "^20.19.7",
+		"@types/serve-favicon": "^2.5.7",
+		"@types/ua-parser-js": "^0.7.39",
 		"compass-importer": "^0.4.1",
 		"gulp": "^5.0.0",
 		"gulp-clean": "^0.4.0",
@@ -30,7 +34,7 @@
 		"gulp-sass": "^5.1.0",
 		"gulp-typescript": "^6.0.0-alpha.1",
 		"sass": "^1.76.0",
-		"typescript": "^5.4.5"
+		"typescript": "^5.8.3"
 	},
 	"dependencies": {
 		"axios": "^1.6.8",

--- a/source/backend/app/app.ts
+++ b/source/backend/app/app.ts
@@ -1,22 +1,26 @@
-import {config} from './config';
+import { config } from './config';
 
-const path         = require('path');
-const http         = require('http');
-const express      = require('express');
-const app          = express();
-const bodyParser   = require('body-parser');
-const cookieParser = require("cookie-parser");
-const favicon      = require('serve-favicon');
+import bodyParser from 'body-parser';
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import session from 'express-session';
+import http from 'http';
+import morgan from 'morgan';
+import path from 'path';
+import favicon from 'serve-favicon';
+import { AvsRandom } from "./lib/random";
+import { AvsStorageSession } from "./storage/session";
 
-const session = require('express-session');
+import * as indexRoute from './route';
+import * as resultRoute from './route/result';
+import * as tokenRoute from './route/token';
+
+const app = express();
 declare module 'express-session' {
 	export interface SessionData {
 		[key: string]: any;
 	}
 }
-
-import {AvsRandom}         from "./lib/random";
-import {AvsStorageSession} from "./storage/session";
 
 const avsStorageInstance = new AvsStorageSession();
 
@@ -33,9 +37,8 @@ app.use(session({
 app.use(express.static('app/frontend'));
 app.use(favicon(path.join(__dirname, '../frontend/static', 'favicon.ico')))
 
-const server = http.Server(app);
+const server = new http.Server(app);
 
-const morgan = require('morgan');
 app.use(morgan('combined'));
 
 app.set('views', config.htmlFilePath);
@@ -44,15 +47,10 @@ app.set('twig options', {
 	strict_variables: false
 });
 app.locals.cacheBuster = config.cacheBuster;
-
-let indexRoute  = require('./route');
-let resultRoute = require('./route/result');
-let tokenRoute  = require('./route/token');
-
 tokenRoute.load(app, avsStorageInstance);
 resultRoute.load(app, avsStorageInstance);
 indexRoute.load(app, avsStorageInstance);
 
 server.listen(config.httpServerPort, config.httpServerHost, () => {
-	console.log('http server started on: ' + config.httpServerHost + ':' + config.httpServerPort);
+	console.log('http server started on: ' + config.httpServerProtocol + '://'  + config.httpServerHost + ':' + config.httpServerPort);
 });

--- a/source/backend/app/lib/encryption.ts
+++ b/source/backend/app/lib/encryption.ts
@@ -1,6 +1,5 @@
-import {config} from "../config";
-
-const crypto = require('crypto');
+import crypto from 'crypto';
+import { config } from "../config";
 
 export class AvsEncryption {
 

--- a/source/backend/app/lib/random.ts
+++ b/source/backend/app/lib/random.ts
@@ -1,14 +1,13 @@
-const Crypto = require('crypto');
+import crypto from 'crypto';
 
 export class AvsRandom {
 
 	static generateRandomString(length = 16) {
 
-		return Crypto
+		return crypto
 			.randomBytes(length)
 			.toString('base64')
 			.slice(0, length);
-
 	}
 
 }

--- a/source/backend/app/route/index.ts
+++ b/source/backend/app/route/index.ts
@@ -1,12 +1,11 @@
-import Express = require('express');
-import URL = require('url');
-import {AvsEncryption}     from '../lib/encryption';
-import {config}            from "../config";
-import {AvsResponse}       from "../lib/response";
-import {AvsStorageSession} from "../storage/session";
-
-const fs   = require('node:fs');
-const path = require('path');
+import Express from 'express';
+import fs from 'node:fs';
+import path from 'path';
+import url from 'url';
+import { config } from "../config";
+import { AvsEncryption } from '../lib/encryption';
+import { AvsResponse } from "../lib/response";
+import { AvsStorageSession } from "../storage/session";
 
 export function load(app: Express.Application, storage: AvsStorageSession) {
 
@@ -95,7 +94,7 @@ export function load(app: Express.Application, storage: AvsStorageSession) {
 				d: requestPayload
 			},
 		};
-		const urlTokenString = URL.format(urlToken);
+		const urlTokenString = url.format(urlToken);
 
 		const urlIframe       = {
 			protocol: config.httpServerProtocol,
@@ -106,7 +105,7 @@ export function load(app: Express.Application, storage: AvsStorageSession) {
 				d: requestPayload
 			},
 		};
-		const urlIframeString = URL.format(urlIframe);
+		const urlIframeString = url.format(urlIframe);
 
 		res.send(AvsResponse.successResponse({
 			payload  : requestPayload,
@@ -148,7 +147,7 @@ export function load(app: Express.Application, storage: AvsStorageSession) {
 		fs.appendFile(
 			path.join(__dirname, './../../../log/callback.log'),
 			responseString,
-			(err: Error) => {
+			(err: any) => {
 				if (err) {
 					res.send(AvsResponse.errorResponse(30004, 'Callback file log error: ' + err.toString()));
 					return;

--- a/source/backend/app/route/result.ts
+++ b/source/backend/app/route/result.ts
@@ -1,7 +1,7 @@
-import Express = require('express');
-import {AvsResponse}       from "../lib/response";
-import {AvsStorageSession} from "../storage/session";
-import {config}            from "../config";
+import Express from 'express';
+import { config } from "../config";
+import { AvsResponse } from "../lib/response";
+import { AvsStorageSession } from "../storage/session";
 
 const ROUTE_ROOT: string = '/result';
 

--- a/source/backend/app/route/token.ts
+++ b/source/backend/app/route/token.ts
@@ -1,10 +1,9 @@
-import Express = require('express');
-import {config}            from '../config';
-import {AvsEncryption}     from '../lib/encryption';
-import {AvsRandom}         from '../lib/random';
-import {AvsStorageSession} from "../storage/session";
-
-const uaParser = require('ua-parser-js');
+import Express from 'express';
+import uaParser from 'ua-parser-js';
+import { config } from '../config';
+import { AvsEncryption } from '../lib/encryption';
+import { AvsRandom } from '../lib/random';
+import { AvsStorageSession } from "../storage/session";
 
 const ROUTE_ROOT = '/token';
 

--- a/source/backend/app/storage/payload.ts
+++ b/source/backend/app/storage/payload.ts
@@ -1,4 +1,4 @@
-import {config} from "../config";
+import { config } from "../config";
 
 export class AvsStoragePayload {
 

--- a/source/backend/app/storage/session.ts
+++ b/source/backend/app/storage/session.ts
@@ -1,8 +1,7 @@
-import {AvsEncryption}        from "../lib/encryption";
-import {AvsStoragePayload}    from "./payload";
-import axios, {AxiosResponse} from "axios";
-
-const uaParser = require('ua-parser-js');
+import axios, { AxiosResponse } from "axios";
+import uaParser from 'ua-parser-js';
+import { AvsEncryption } from "../lib/encryption";
+import { AvsStoragePayload } from "./payload";
 
 export class AvsStorageSession {
 
@@ -281,7 +280,7 @@ export interface ISessionListItem {
 	ipState: string,
 	websiteHostname: string,
 	verificationVersion: number,
-	deviceType: string,
+	deviceType?: string,
 	userAgent: string,
 	state: string,
 	stateInt: number,

--- a/source/backend/tsconfig.json
+++ b/source/backend/tsconfig.json
@@ -3,7 +3,6 @@
 		"ignoreDeprecations": "5.0",
 		"module": "commonjs",
 		"esModuleInterop": true,
-		"charset": "utf-8",
 		"target": "es2017",
 		"moduleResolution": "node",
 		"removeComments": false,

--- a/source/frontend/js/tsconfig.json
+++ b/source/frontend/js/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"compilerOptions": {
 		"ignoreDeprecations": "5.0",
-		"charset": "utf-8",
-		"target": "es3",
+		"target": "es5",
 		"removeComments": false,
 		"preserveConstEnums": false,
 		"noImplicitReturns": true,


### PR DESCRIPTION
# Update Summary

Updating package dev dependencies to include security fixes and type script definitions for third party moduals. Also changed backend source `require` to `import` to avoid mixing ES vs CommonJS. Updated tsconfig files to remove deprecated `charset` option and changed frontend target to `es5`. 

## Changes
- Added `protocol` to server startup console message
- Updated`package.json` dev dependencies
  - Added typescript definitions for:
    - `morgan`
    - `node`
    - `serve-favicon`
    - `ua-parser-js`
    - `cookie-parser`
  - Updated `node` typescript definition to `^20.19.7`
  - Updated typescript version to `^5.8.3` 
- Changing `require` to `import` in backend source files
- Updated `backend/tsconfig.json`
  - Removed `"charset"` option has it has sense [been depreciated](https://www.typescriptlang.org/tsconfig/#charset)
- Updated `frontend/js/tsconfig.json`
  - Removed `"charset"` option has it has sense [been depreciated](https://www.typescriptlang.org/tsconfig/#charset)
  - Changed `"target"` to `"es5"`