### PR TITLE
chore: add isProduction flag to differentiate demo and production

### DIFF
--- a/app/backend/app.js
+++ b/app/backend/app.js
@@ -72,6 +72,7 @@ app.set('twig options', {
     strict_variables: false
 });
 app.locals.cacheBuster = config_1.config.cacheBuster;
+app.locals.isProduction = config_1.config.isProduction;
 tokenRoute.load(app, avsStorageInstance);
 resultRoute.load(app, avsStorageInstance);
 indexRoute.load(app, avsStorageInstance);

--- a/app/backend/config/index.js
+++ b/app/backend/config/index.js
@@ -29,6 +29,7 @@ const configObject = {
     },
     cacheBuster: +new Date(),
     enableFrontEndDebug: process.env.ENABLE_FRONTEND_DEBUG || false,
+    isProduction: process.env.NODE_ENV === 'production',
     countryAgeMajority: {
         "A1": 18,
         "A2": 18,

--- a/app/frontend/views/base.twig
+++ b/app/frontend/views/base.twig
@@ -4,8 +4,8 @@
 	<meta name="robots" content="noindex">
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
-	<title>Go.cam demo</title>
-	<meta name="description" content="Age verification system - demo">
+	<title>Go.cam{% if not isProduction %} demo{% endif %}</title>
+	<meta name="description" content="Age verification system{% if not isProduction %} - demo{% endif %}">
 
 	{% block head %}{% endblock %}
 


### PR DESCRIPTION
Helps differentiate between production and demo/staging environments at a glance, which can prevent mistakes (e.g., sharing a staging URL thinking it’s production)

Right now demo is hardcoded into the title

